### PR TITLE
Fixes Slack webhook for Jumpcloud MDM

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -2792,11 +2792,11 @@ webHookMessage() {
             # For cases when the device id is not found in the logs
                 mdmComputerURL="https://intune.microsoft.com/#view/Microsoft_Intune_DeviceSettings/DevicesMacOsMenu/~/macOsDevices"
             fi
-	    # If Mac is managed by Jumpcloud, link to the Jumpcloud devices page
-	    elif [[  $mdmName == "Jumpcloud" ]]; then
+        # If Mac is managed by Jumpcloud, link to the Jumpcloud devices page
+	elif [[  $mdmName == "Jumpcloud" ]]; then
             mdmComputerURL="https://console.jumpcloud.com/#/devices/list"
     	else
-	        log_info "No MDM determined - webhook call will fail"
+	    log_info "No MDM determined - webhook call will fail"
         fi
 
         log_info "Sending Slack WebHook"
@@ -2891,11 +2891,12 @@ webHookMessage() {
                 mdmComputerURL="https://intune.microsoft.com/#view/Microsoft_Intune_DeviceSettings/DevicesMacOsMenu/~/macOsDevices"
             fi
         # If Mac is managed by Jumpcloud, link to the Jumpcloud devices page
-	    elif [[  $mdmName == "Jumpcloud" ]]; then
+	elif [[  $mdmName == "Jumpcloud" ]]; then
             mdmComputerURL="https://console.jumpcloud.com/#/devices/list"
     	else
-	        log_info "No MDM determined - webhook call will fail"
+            log_info "No MDM determined - webhook call will fail"
         fi
+
         log_info "Sending Teams WebHook"
         jsonPayload='{
     "@type": "MessageCard",


### PR DESCRIPTION
When trialling AAP on a Jumpcloud enrolled Mac, the Slack webhook was failing.
On investigation, this was due to mdmComputerURL only being set if the MDM is Jamf or Intune.

This commit adds a quick fix to set the URL for Jumpcloud, so that the Slack webhook succeeds. 

I'm uncertain if it's possible to gather the Jumpcloud device id to construct a deep link to the actual device information, so it links to the device page (with all devices) instead.

Whilst I don't have Teams to test the Teams change, it uses the same approach as Slack.

Also adds verbose logs for the webhook response, to aid debugging.