### PR TITLE
Remove hard coded "/Library/Managment/" references and unecessary chm…

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -2198,8 +2198,6 @@ log_install "Creating AAP LaunchDaemon: /Library/LaunchDaemons/${appAutoPatchLau
 EOLD
 
 log_install "Setting permissions for installed items"
-chown root:wheel "/Library/Management"
-chmod 777 "/Library/Management"
 chown -R root:wheel "${appAutoPatchFolder}"
 chmod -R 777 "${appAutoPatchFolder}"
 chmod -R a+r "${appAutoPatchFolder}"
@@ -2347,7 +2345,7 @@ get_installomator() {
             echo "Pulling from custom installomator"
             latestURL="https://codeload.github.com/$installomatorVersionCustomRepoPath/legacy.tar.gz/$(curl -sSL -o - "https://api.github.com/repos/$installomatorVersionCustomRepoPath/branches" | grep -A2 "$installomatorVersionCustomBranchName" | tail -1 | cut -d'"' -f4)"
             appNewVersion="$(curl -sL "https://raw.githubusercontent.com/$installomatorVersionCustomRepoPath/refs/heads/$installomatorVersionCustomBranchName/Installomator.sh" | grep VERSIONDATE= | cut -d'"' -f2)"
-            appVersion="$(cat "/Library/Management/AppAutoPatch/Installomator/Installomator.sh" | grep VERSIONDATE= | cut -d'"' -f2)"
+            appVersion="$(cat "${installomatorScript}" | grep VERSIONDATE= | cut -d'"' -f2)"
             # convert to epoch
             appNewVersion=$(date -j -f "%Y-%m-%d" "${appNewVersion}" +%s)
             appVersion=$(date -j -f "%Y-%m-%d" "${appVersion}" +%s)
@@ -2355,7 +2353,7 @@ get_installomator() {
             echo "Pulling from Installomator Main Branch"
             latestURL="https://codeload.github.com/Installomator/Installomator/legacy.tar.gz/$(curl -sSL -o - "https://api.github.com/repos/Installomator/Installomator/branches" | grep -A2 "main" | tail -1 | cut -d'"' -f4)"
             appNewVersion="$(curl -sL "https://raw.githubusercontent.com/Installomator/Installomator/refs/heads/main/Installomator.sh" | grep VERSIONDATE= | cut -d'"' -f2)"
-            appVersion="$(cat "/Library/Management/AppAutoPatch/Installomator/Installomator.sh" | grep VERSIONDATE= | cut -d'"' -f2)"
+            appVersion="$(cat "${installomatorScript}" | grep VERSIONDATE= | cut -d'"' -f2)"
             # convert to epoch
             appNewVersion=$(date -j -f "%Y-%m-%d" "${appNewVersion}" +%s)
             appVersion=$(date -j -f "%Y-%m-%d" "${appVersion}" +%s)


### PR DESCRIPTION
…od/chown

Removed:
2201 chown root: wheel "/Library/Management"
2202 chmod 777 "/Library/Management"
Justification:
If /Library/Managment or any other directory is created by the script it will be "root: wheel" 755 by default.  If the folder exists with custom permissions, those shouldn't be changed. All other permissions for the "${appAutoPatchFolder}" directory and below are set elsewhere in the script.

Line 2350 and 2358, updated hard coded reference to "/Library/Managment/AppAutoPatch/Installomator/Installomater.sh" to "${installomatorScript}" Justification: 
Script was failing to find and version "Installomator.sh" if a custom ${appAutoPatchFolder} was set.