### PR TITLE
Self Service Overlay Icon Path Fix, "Plus" Support Update

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -2001,9 +2001,13 @@ workflow_startup() {
 
     # Create `overlayicon` from Self Service's custom icon (thanks, @meschwartz!)
     if [[ "$useOverlayIcon" == "TRUE" ]]; then
-        if defaults read /Library/Preferences/com.jamfsoftware.jamf self_service_app_path &> /dev/null; then
+        if [[ -n "$(defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_app_path)" ]]; then
             # Use Self Service icon for overlay if found
-            xxd -p -s 260 "$(defaults read /Library/Preferences/com.jamfsoftware.jamf self_service_app_path)"/Icon$'\r'/..namedfork/rsrc | xxd -r -p > /var/tmp/overlayicon.icns
+            xxd -p -s 260 "$(defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_app_path)"/Icon$'\r'/..namedfork/rsrc | xxd -r -p > /var/tmp/overlayicon.icns
+            overlayicon="/var/tmp/overlayicon.icns"
+        elif [[ -n "$(defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_plus_path)" ]]; then
+            # Use Self Service Plus icon for overlay if found
+            xxd -p -s 260 "$(defaults read /Library/Preferences/com.jamfsoftware.jamf.plist self_service_plus_path)"/Icon$'\r'/..namedfork/rsrc | xxd -r -p > /var/tmp/overlayicon.icns
             overlayicon="/var/tmp/overlayicon.icns"
         # Computer is not Jamf enrolled (or can't use Self Service logo), get a different overlay icon
         elif [[ -e "/Library/Application Support/JAMF/Jamf.app" ]]; then


### PR DESCRIPTION
- Fixes the pathing for the Self Service overlay icon, which was previously not returning correctly and resulted in a "?" icon being shown.

- Adds support for orgs that have moved to the new "Self Service+" app, instead of the "Classic" app.