### PR TITLE
Fix regex error parsing

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -3692,7 +3692,7 @@ check_and_echo_errors() {
     lastPosition=$(cat "$marker_file")
     log_info "Last position: $lastPosition"
     
-    result=$(grep -a 'ERROR\s\+:\s\+\S\+\s\+:\s\+ERROR:' "$duplicate_installomatorLogFile" | awk -F 'ERROR :' '{print $2}')
+	result="$(grep -aE 'ERROR[[:space:]]*:[[:space:]]*[^:]+[[:space:]]*:[[:space:]]*' "$duplicate_installomatorLogFile" | awk -F ' : ' '$2=="ERROR"{print $3 " : " $4; exit}')"
     #log_info "Install Error Result: $result"
     
     #Function to print with bullet points


### PR DESCRIPTION
Fixes error extraction from Installomator logs. Used in webhooks. Previous implementation returned null.

- Replaces non-portable `\s\+` / `\S\+` regex (which fails on macOS `grep`) with POSIX-compliant `[[:space:]]*` and `[^:]+`.
- Updates `awk` field splitting to use `" : "` delimiter, matching the log’s actual format (`timestamp : level : label : message`).
- Ensures the script correctly captures both **label** and **message**, for example:

```text
snagit : need to provide 'downloadURL'