### PR TITLE
Webhook Feature Update Slack & Teams

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -4166,67 +4166,37 @@ webHookMessage() {
         
         log_info "Sending Slack WebHook"
         jsonPayload='{
-            "blocks": [
-                {
-                    "type": "header",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "'${webhookStatus}'"
-                    }
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "*'${serialNumber}'* (_'${modelName}'_)"
-                    }
-                },
-                {
-                    "type": "context",
-                    "elements": [
-                        {
-                            "type": "mrkdwn",
-                            "text": "'${currentUserAccountName}'"
-                        }
-                    ]
-                },
-                {
-                    "type": "divider"
-                },
-                {
-                    "type": "section",
-                    "fields": [
-                        {
-                            "type": "mrkdwn",
-                            "text": ">*Label(s):*\n>'"$formatted_result"'"
-                        },
-                        {
-                            "type": "mrkdwn",
-                            "text": ">*Error(s):*\n>'"$formatted_error_result"'"
-                        },
-                        {
-                            "type": "mrkdwn",
-                            "text": ">*Version:*\n>'"*AAP:* $scriptVersion *INSTR:* $(cat "${installomatorScript}" | grep ^VERSION= | head -n1 | cut -d'"' -f2) *OS:* $osVersion"'"
-                        },
-                    ]
-                },
-                {
-                "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {
-                                "type": "plain_text",
-                                "text": "View in '"$mdmName"'",
-                                "emoji": true
-                            },
-                            "style": "primary",
-                            "action_id": "actionId-0",
-                            "url": "'"$mdmComputerURL"'"
-                        }
-                    ]
-                }
+        "blocks": [
+            {
+            "type": "header",
+            "text": { "type": "plain_text", "text": "'${webhookStatus}'" }
+            },
+            {
+            "type": "section",
+            "text": { "type": "mrkdwn", "text": "*'${serialNumber}'* (_'${modelName}'_)" }
+            },
+            {
+            "type": "context",
+            "elements": [
+                { "type": "mrkdwn", "text": "'${currentUserAccountName}'" }
             ]
+            },
+            { "type": "divider" },
+            {
+            "type": "section",
+            "fields": [
+                { "type": "mrkdwn", "text": ">*Label(s):*\n>'"$formatted_result"'" },
+                { "type": "mrkdwn", "text": ">*Error(s):*\n>'"$formatted_error_result"'" },
+                { "type": "mrkdwn", "text": ">*Version:*\n>'"*AAP:* $scriptVersion *INSTR:* $(cat "${installomatorScript}" | grep ^VERSION= | head -n1 | cut -d'"' -f2) *OS:* $osVersion"'" }
+            ]
+            },
+            {
+            "type": "context",
+            "elements": [
+                { "type": "mrkdwn", "text": "<'"$mdmComputerURL"'|View in '"$mdmName"'>" }
+            ]
+            }
+        ]
         }'
         
         curlResult=$(curl -s -X POST -H 'Content-type: application/json' -d "$jsonPayload" "$webhook_url_slack_option")


### PR DESCRIPTION
Updated webhooks for both Slack and Teams to provide more and clearer information.

**Changelog:**
	•	Renamed “Microsoft Intune” to “Intune” to prevent the button text from being truncated.
	•	Shortened the title and added emojis for quick identification of success and failure.
	•	Added version information for OS, Installomator, and AAP.
	•	Removed the computer record URL since the button serves the same purpose.
	•	Removed the hostname because it often matches the S/N, and the S/N is easier to search.
	•	Made the card more compact and information-dense.

**Slack Old:**
<img width="669" height="348" alt="Screenshot 2025-10-20 at 23 19 19" src="https://github.com/user-attachments/assets/06cf1b6b-a81e-4bc5-bcb1-566fd45e5456" />

**Slack New:**
<img width="664" height="304" alt="Screenshot 2025-10-20 at 23 21 14" src="https://github.com/user-attachments/assets/69fdbde9-f167-4bdf-a3d9-7085336da861" />

**Teams Old:**
<img width="511" height="311" alt="Screenshot 2025-10-20 at 23 22 45" src="https://github.com/user-attachments/assets/57b407d1-4f5a-48e7-a247-8dcc2f96bc88" />

**Teams New:**
<img width="532" height="316" alt="Screenshot 2025-10-20 at 23 22 02" src="https://github.com/user-attachments/assets/167b0d18-4907-4998-9382-05ad966f9b77" />
