### PR TITLE
fix: security vulnerabilities in permissions and eval

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -2522,7 +2522,7 @@ EOLD
 
     log_install "Setting permissions for installed items"
     chown -R root:wheel "${appAutoPatchFolder}"
-    chmod -R 777 "${appAutoPatchFolder}"
+    chmod -R 755 "${appAutoPatchFolder}"
     chmod -R a+r "${appAutoPatchFolder}"
     chmod -R go-w "${appAutoPatchFolder}"
     chmod a+x "${appAutoPatchFolder}/appautopatch"
@@ -4739,11 +4739,22 @@ main() {
                         [[ -z $current_label ]] && current_label=$line || current_label=$current_label$'\n'$line
                         
                         case $scrubbedLine in
-                            
-                            'name='*|'appName='*|'packageID'*|'expectedTeamID'*)
-                                eval "$scrubbedLine"
+                            'name='*)
+                                name="${scrubbedLine#name=}"
+                                name="${name//\"/}"
                             ;;
-                            
+                            'appName='*)
+                                appName="${scrubbedLine#appName=}"
+                                appName="${appName//\"/}"
+                            ;;
+                            'packageID='*)
+                                packageID="${scrubbedLine#packageID=}"
+                                packageID="${packageID//\"/}"
+                            ;;
+                            'expectedTeamID='*)
+                                expectedTeamID="${scrubbedLine#expectedTeamID=}"
+                                expectedTeamID="${expectedTeamID//\"/}"
+                            ;;
                         esac
                     fi
                 fi


### PR DESCRIPTION
## Changes
- `chmod -R 777` → `chmod -R 755` (line 2525) - prevents world-writable race condition
- `eval "$scrubbedLine"` → safe parameter expansion (line 4744) - prevents command injection

## Note
Additional `eval` usages at lines 3863 and 4685 require larger refactors.