### PR TITLE
Port ScheduleWorkflowActive (#166) onto 3.7.0

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -67,6 +67,9 @@ echo "
     [--workflow-install-now-patching-status-action-never]
     [--workflow-install-now-patching-status-action-always]
     [--workflow-install-now-patching-status-action-success]
+    [--schedule-workflow-active=DAY:hh:mm-hh:mm,...]
+    [--schedule-workflow-active-respect-hard-deadline]
+    [--schedule-workflow-active-respect-hard-deadline-off]
 
     Deferral Deadline COUNT Options:
     [--deadline-count-focus=number]
@@ -170,6 +173,8 @@ echo "
     <key>WorkflowStageUpdates</key> <true/> | <false/>
     <key>WorkflowDisableAppDiscovery</key> <true/> | <false/>
     <key>WorkflowDisableRelaunch</key> <true/> | <false/>
+    <key>ScheduleWorkflowActive</key> <string>MON:17:00-23:59,TUE:17:00-23:59,...</string>
+    <key>ScheduleWorkflowActiveRespectHardDeadline</key> <true/> | <false/>
     <key>DiscoveryFrequency</key> <integer>hours</integer>
     <key>WorkflowInstallNowPatchingStatusAction</key> <string>NEVER | ALWAYS | SUCCESS</string>
     <key>ZoomCallActiveCheck</key> <true/> | <false/>
@@ -312,6 +317,13 @@ set_defaults() {
     daysUntilReset="1" # MDM Enabled
 
     workflow_install_now_patching_status_action_option="SUCCESS" # MDM Enabled - Determines what happens when  NEVER | ALWAYS | SUCCESS 
+
+    # ScheduleWorkflowActive (#166) - SUPER-compatible DAY:hh:mm-hh:mm windows. Empty/unset = always active.
+    # Local Mac timezone; same-day ranges only. Outside a window: reschedule NextAutoLaunch to next window start.
+    schedule_workflow_active_option="" # MDM Enabled
+    # Empty until prefs resolve; managed/CLI/local then normalize to FALSE (default: hard deadline bypasses window) or TRUE.
+    schedule_workflow_active_respect_hard_deadline_option="" # MDM Enabled
+    typeset -ga schedule_workflow_active_windows # populated by manage_parameter_options: "dow:startmin:endmin"
 
     UnattendedExit="FALSE" # MDM Enabled
 
@@ -989,6 +1001,15 @@ get_options() {
             --workflow-disable-relaunch-off)
                 workflow_disable_relaunch_option="FALSE"
             ;;
+            --schedule-workflow-active=*)
+                schedule_workflow_active_option="${1##*=}"
+            ;;
+            --schedule-workflow-active-respect-hard-deadline)
+                schedule_workflow_active_respect_hard_deadline_option="TRUE"
+            ;;
+            --schedule-workflow-active-respect-hard-deadline-off)
+                schedule_workflow_active_respect_hard_deadline_option="FALSE"
+            ;;
             --webhook-feature-off)
                 webhook_feature_option="FALSE"
             ;;
@@ -1158,6 +1179,10 @@ get_preferences() {
         discovery_frequency_managed=$(defaults read "${appAutoPatchManagedPLIST}" DiscoveryFrequency 2> /dev/null)
         local workflow_disable_relaunch_managed
         workflow_disable_relaunch_managed=$(defaults read "${appAutoPatchManagedPLIST}" WorkflowDisableRelaunch 2>/dev/null)
+        local schedule_workflow_active_managed
+        schedule_workflow_active_managed=$(defaults read "${appAutoPatchManagedPLIST}" ScheduleWorkflowActive 2>/dev/null)
+        local schedule_workflow_active_respect_hard_deadline_managed
+        schedule_workflow_active_respect_hard_deadline_managed=$(defaults read "${appAutoPatchManagedPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null)
         local webhook_feature_managed
         webhook_feature_managed=$(defaults read "${appAutoPatchManagedPLIST}" WebhookFeature 2> /dev/null)
         local webhook_url_slack_managed
@@ -1296,6 +1321,10 @@ get_preferences() {
         discovery_frequency_local=$(defaults read "${appAutoPatchLocalPLIST}" DiscoveryFrequency 2> /dev/null)
         local workflow_disable_relaunch_local
         workflow_disable_relaunch_local=$(defaults read "${appAutoPatchLocalPLIST}" WorkflowDisableRelaunch 2>/dev/null)
+        local schedule_workflow_active_local
+        schedule_workflow_active_local=$(defaults read "${appAutoPatchLocalPLIST}" ScheduleWorkflowActive 2>/dev/null)
+        local schedule_workflow_active_respect_hard_deadline_local
+        schedule_workflow_active_respect_hard_deadline_local=$(defaults read "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null)
         local webhook_feature_local
         webhook_feature_local=$(defaults read "${appAutoPatchLocalPLIST}" WebhookFeature 2> /dev/null)
         local webhook_url_slack_local
@@ -1422,6 +1451,10 @@ get_preferences() {
     { [[ -z "${discovery_frequency_managed}" ]] && [[ -n "${discovery_frequency_local}" ]]; } && DiscoveryFrequency="${discovery_frequency_local}"
     [[ -n "${workflow_disable_relaunch_managed}" ]] && workflow_disable_relaunch_option="${workflow_disable_relaunch_managed}"
     { [[ -z "${workflow_disable_relaunch_managed}" ]] && [[ -z "${workflow_disable_relaunch_option}" ]] && [[ -n "${workflow_disable_relaunch_local}" ]]; } && workflow_disable_relaunch_option="${workflow_disable_relaunch_local}"
+    [[ -n "${schedule_workflow_active_managed}" ]] && schedule_workflow_active_option="${schedule_workflow_active_managed}"
+    { [[ -z "${schedule_workflow_active_managed}" ]] && [[ -z "${schedule_workflow_active_option}" ]] && [[ -n "${schedule_workflow_active_local}" ]]; } && schedule_workflow_active_option="${schedule_workflow_active_local}"
+    [[ -n "${schedule_workflow_active_respect_hard_deadline_managed}" ]] && schedule_workflow_active_respect_hard_deadline_option="${schedule_workflow_active_respect_hard_deadline_managed}"
+    { [[ -z "${schedule_workflow_active_respect_hard_deadline_managed}" ]] && [[ -z "${schedule_workflow_active_respect_hard_deadline_option}" ]] && [[ -n "${schedule_workflow_active_respect_hard_deadline_local}" ]]; } && schedule_workflow_active_respect_hard_deadline_option="${schedule_workflow_active_respect_hard_deadline_local}"
     [[ -n "${webhook_feature_managed}" ]] && webhook_feature_option="${webhook_feature_managed}"
     { [[ -z "${webhook_feature_managed}" ]] && [[ -z "${webhook_feature_option}" ]] && [[ -n "${webhook_feature_local}" ]]; } && webhook_feature_option="${webhook_feature_local}"
     [[ -n "${webhook_url_slack_managed}" ]] && webhook_url_slack_option="${webhook_url_slack_managed}"
@@ -1567,6 +1600,8 @@ get_preferences() {
     log_verbose "WorkflowDisableAppDiscovery: $workflow_disable_app_discovery_option"
     log_verbose "DiscoveryFrequency: $DiscoveryFrequency"
     log_verbose "WorkflowDisableRelaunch: $workflow_disable_relaunch_option"
+    log_verbose "ScheduleWorkflowActive: ${schedule_workflow_active_option:-<unset>}"
+    log_verbose "ScheduleWorkflowActiveRespectHardDeadline: ${schedule_workflow_active_respect_hard_deadline_option:-<unset>}"
     log_verbose "WebhookFeature: $webhook_feature_option"
     log_verbose "WebhookURLSlack: $webhook_url_slack_option"
     log_verbose "WebhookURLTeams: $webhook_url_teams_option"
@@ -2027,6 +2062,76 @@ manage_parameter_options() {
         defaults delete "${appAutoPatchLocalPLIST}" NextAutoLaunch 2> /dev/null
     fi
     { [[ -n "${workflow_disable_relaunch_option}" ]]; } && log_verbose "workflow_disable_relaunch_option is: ${workflow_disable_relaunch_option}"
+
+    # Manage ScheduleWorkflowActive (#166): parse SUPER-compatible DAY:hh:mm-hh:mm windows.
+    schedule_workflow_active_windows=()
+    if [[ -n "${schedule_workflow_active_option}" ]]; then
+        # Strip whitespace; SUPER format is comma-separated with no spaces.
+        local schedule_cleaned
+        schedule_cleaned="${schedule_workflow_active_option//[[:space:]]/}"
+        if [[ -z "${schedule_cleaned}" ]]; then
+            schedule_workflow_active_option=""
+            defaults delete "${appAutoPatchLocalPLIST}" ScheduleWorkflowActive 2>/dev/null
+        else
+            local schedule_parse_error="FALSE"
+            local schedule_window
+            local schedule_day schedule_start schedule_end
+            local schedule_start_h schedule_start_m schedule_end_h schedule_end_m
+            local schedule_start_mins schedule_end_mins schedule_dow
+            for schedule_window in ${(s:,:)schedule_cleaned}; do
+                if [[ ! "${schedule_window}" =~ '^(MON|TUE|WED|THU|FRI|SAT|SUN):([0-9]{2}):([0-9]{2})-([0-9]{2}):([0-9]{2})$' ]]; then
+                    log_status "Parameter Error: ScheduleWorkflowActive window '${schedule_window}' must be DAY:hh:mm-hh:mm (MON-SUN, 24-hour)."; schedule_parse_error="TRUE"
+                    continue
+                fi
+                schedule_day="${match[1]}"
+                schedule_start_h="${match[2]}"
+                schedule_start_m="${match[3]}"
+                schedule_end_h="${match[4]}"
+                schedule_end_m="${match[5]}"
+                if (( 10#${schedule_start_h} > 23 || 10#${schedule_end_h} > 23 || 10#${schedule_start_m} > 59 || 10#${schedule_end_m} > 59 )); then
+                    log_status "Parameter Error: ScheduleWorkflowActive window '${schedule_window}' has an invalid time."; schedule_parse_error="TRUE"
+                    continue
+                fi
+                schedule_start_mins=$(( 10#${schedule_start_h} * 60 + 10#${schedule_start_m} ))
+                schedule_end_mins=$(( 10#${schedule_end_h} * 60 + 10#${schedule_end_m} ))
+                if (( schedule_start_mins > schedule_end_mins )); then
+                    log_status "Parameter Error: ScheduleWorkflowActive window '${schedule_window}' must be same-day with start <= end (split overnight ranges into two windows)."; schedule_parse_error="TRUE"
+                    continue
+                fi
+                case "${schedule_day}" in
+                    MON) schedule_dow=1 ;;
+                    TUE) schedule_dow=2 ;;
+                    WED) schedule_dow=3 ;;
+                    THU) schedule_dow=4 ;;
+                    FRI) schedule_dow=5 ;;
+                    SAT) schedule_dow=6 ;;
+                    SUN) schedule_dow=7 ;;
+                esac
+                schedule_workflow_active_windows+=("${schedule_dow}:${schedule_start_mins}:${schedule_end_mins}")
+            done
+            if [[ "${schedule_parse_error}" == "TRUE" ]] || [[ ${#schedule_workflow_active_windows[@]} -eq 0 ]]; then
+                log_status "Parameter Error: ScheduleWorkflowActive value is invalid: ${schedule_workflow_active_option}"; option_error="TRUE"
+                schedule_workflow_active_windows=()
+            else
+                schedule_workflow_active_option="${schedule_cleaned}"
+                defaults write "${appAutoPatchLocalPLIST}" ScheduleWorkflowActive -string "${schedule_workflow_active_option}"
+                log_verbose "schedule_workflow_active_windows: ${schedule_workflow_active_windows[*]}"
+            fi
+        fi
+    else
+        defaults delete "${appAutoPatchLocalPLIST}" ScheduleWorkflowActive 2>/dev/null
+    fi
+    { [[ -n "${schedule_workflow_active_option}" ]]; } && log_verbose "schedule_workflow_active_option is: ${schedule_workflow_active_option}"
+
+    # Manage ScheduleWorkflowActiveRespectHardDeadline (default FALSE = overdue hard deadline bypasses the window).
+    if [[ "${schedule_workflow_active_respect_hard_deadline_option}" -eq 1 ]] || [[ "${schedule_workflow_active_respect_hard_deadline_option}" == "TRUE" ]]; then
+        schedule_workflow_active_respect_hard_deadline_option="TRUE"
+        defaults write "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveRespectHardDeadline -bool true
+    else
+        schedule_workflow_active_respect_hard_deadline_option="FALSE"
+        defaults delete "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null
+    fi
+    log_verbose "schedule_workflow_active_respect_hard_deadline_option is: ${schedule_workflow_active_respect_hard_deadline_option}"
     
     # Manage ${zoom_call_active_check_option} and save to ${appAutoPatchLocalPLIST}.
     if [[ "${zoom_call_active_check_option}" -eq 1 ]] || [[ "${zoom_call_active_check_option}" == "TRUE" ]]; then
@@ -2654,6 +2759,10 @@ workflow_startup() {
 		write_status "Inactive Error: Initial startup validation failed."
 		exit_error
 	fi
+
+	# ScheduleWorkflowActive early gate (#166): after prefs/validation and install-now flags resolve,
+	# before Jamf restart / network wait / discovery. Option B lightweight hard-deadline read may bypass.
+	enforce_schedule_workflow_active
 	
 	# If aap is running via Jamf, then restart via LaunchDaemon to release the jamf parent process.
 	if [[ "${parent_process_is_jamf}" == "TRUE" ]]; then
@@ -4053,10 +4162,179 @@ check_deadlines_count() {
     log_verbose  "user_focus_active is: ${user_focus_active}"
 }
 
+# Evaluate ScheduleWorkflowActive windows (#166). Windows are stored as "dow:startmin:endmin"
+# where dow matches `date +%u` (1=Mon ... 7=Sun) and minutes are inclusive on both ends.
+
+is_epoch_in_schedule_workflow_active() {
+    local target_epoch="${1}"
+    if [[ ${#schedule_workflow_active_windows[@]} -eq 0 ]]; then
+        return 0
+    fi
+    local target_dow target_mins
+    target_dow=$(date -r "${target_epoch}" +%u)
+    target_mins=$(( 10#$(date -r "${target_epoch}" +%H) * 60 + 10#$(date -r "${target_epoch}" +%M) ))
+    local window window_dow window_start window_end window_rest
+    for window in "${schedule_workflow_active_windows[@]}"; do
+        window_dow="${window%%:*}"
+        window_rest="${window#*:}"
+        window_start="${window_rest%%:*}"
+        window_end="${window_rest#*:}"
+        if [[ "${window_dow}" == "${target_dow}" ]] && (( target_mins >= window_start && target_mins <= window_end )); then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Earliest window-start epoch at or after ${1}. Echoes epoch to stdout only (safe for $(...)).
+next_schedule_workflow_active_start_epoch() {
+    local after_epoch="${1}"
+    local day_offset=0
+    local day_midnight day_dow candidate
+    local window window_dow window_start window_end window_rest
+    local best_epoch=""
+    # Search up to 8 days ahead so a schedule with only future weekdays still resolves.
+    while (( day_offset <= 7 )); do
+        day_midnight=$(date -j -v+"${day_offset}"d -f "%Y-%m-%d %H:%M:%S" "$(date -r "${after_epoch}" +%Y-%m-%d) 00:00:00" +%s 2>/dev/null)
+        if [[ -z "${day_midnight}" ]]; then
+            day_offset=$((day_offset + 1))
+            continue
+        fi
+        day_dow=$(date -r "${day_midnight}" +%u)
+        for window in "${schedule_workflow_active_windows[@]}"; do
+            window_dow="${window%%:*}"
+            window_rest="${window#*:}"
+            window_start="${window_rest%%:*}"
+            window_end="${window_rest#*:}"
+            if [[ "${window_dow}" != "${day_dow}" ]]; then
+                continue
+            fi
+            candidate=$(( day_midnight + window_start * 60 ))
+            if (( candidate >= after_epoch )); then
+                if [[ -z "${best_epoch}" ]] || (( candidate < best_epoch )); then
+                    best_epoch="${candidate}"
+                fi
+            fi
+        done
+        if [[ -n "${best_epoch}" ]]; then
+            echo "${best_epoch}"
+            return 0
+        fi
+        day_offset=$((day_offset + 1))
+    done
+    # Fallback: after_epoch + 24h if somehow no window matched (should not happen after validation).
+    echo $(( after_epoch + 86400 ))
+}
+
+# If epoch is inside a configured window (or no schedule), return it unchanged; otherwise next window start.
+# Echoes epoch only — callers log when the value changes.
+clamp_epoch_to_schedule_workflow_active() {
+    local target_epoch="${1}"
+    if [[ ${#schedule_workflow_active_windows[@]} -eq 0 ]]; then
+        echo "${target_epoch}"
+        return 0
+    fi
+    if is_epoch_in_schedule_workflow_active "${target_epoch}"; then
+        echo "${target_epoch}"
+        return 0
+    fi
+    next_schedule_workflow_active_start_epoch "${target_epoch}"
+}
+
+# Lightweight hard-deadline check for the early ScheduleWorkflowActive gate (option B).
+# Read-only: does not mutate DeadlineCounter* and does not sleep near a days deadline.
+# Returns 0 when a hard days/count deadline is already due (or within 120s for days).
+is_hard_deadline_due_lightweight() {
+    local current_epoch
+    current_epoch=$(date +%s)
+
+    if [[ -n "${deadline_days_hard}" ]]; then
+        local patching_start_raw patching_start_date zero_epoch hard_epoch hard_diff
+        patching_start_raw=$(defaults read "${appAutoPatchLocalPLIST}" AAPPatchingStartDate 2>/dev/null)
+        if [[ -n "${patching_start_raw}" ]]; then
+            patching_start_date="${patching_start_raw:0:10}"
+            zero_epoch=$(date -j -f "%Y-%m-%d" "${patching_start_date}" +%s 2>/dev/null)
+            if [[ -n "${zero_epoch}" ]] && [[ -n "${deadline_days_hard_seconds}" ]]; then
+                hard_epoch=$(( zero_epoch + deadline_days_hard_seconds ))
+                hard_diff=$(( hard_epoch - current_epoch ))
+                if (( hard_epoch <= current_epoch )) || (( hard_diff <= 120 )); then
+                    return 0
+                fi
+            fi
+        fi
+    fi
+
+    if [[ -n "${deadline_count_hard}" ]]; then
+        local deadline_counter_hard_previous deadline_counter_hard_current
+        deadline_counter_hard_previous=$(defaults read "${appAutoPatchLocalPLIST}" DeadlineCounterHard 2>/dev/null)
+        if [[ -z "${deadline_counter_hard_previous}" ]]; then
+            deadline_counter_hard_current=0
+        else
+            deadline_counter_hard_current=$(( deadline_counter_hard_previous + 1 ))
+        fi
+        if (( deadline_counter_hard_current >= deadline_count_hard )); then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Early gate: outside ScheduleWorkflowActive, reschedule to next window start and exit cleanly.
+# Bypassed by install-now / preview-deferral-dialog, and by overdue hard deadline unless RespectHardDeadline is TRUE.
+enforce_schedule_workflow_active() {
+    if [[ ${#schedule_workflow_active_windows[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    if [[ "${workflow_install_now_option}" == "TRUE" ]] || [[ "${workflow_install_now_silent_option}" == "TRUE" ]] || [[ "${preview_deferral_dialog_option}" == "TRUE" ]]; then
+        log_status "ScheduleWorkflowActive bypassed (install-now or preview-deferral-dialog)."
+        return 0
+    fi
+
+    if [[ "${schedule_workflow_active_respect_hard_deadline_option}" != "TRUE" ]] && is_hard_deadline_due_lightweight; then
+        log_status "Hard deadline due; bypassing ScheduleWorkflowActive."
+        return 0
+    fi
+
+    local now_epoch
+    now_epoch=$(date +%s)
+    if is_epoch_in_schedule_workflow_active "${now_epoch}"; then
+        log_verbose "Within ScheduleWorkflowActive window; continuing workflow."
+        return 0
+    fi
+
+    log_status "Outside ScheduleWorkflowActive window (${schedule_workflow_active_option})."
+
+    if [[ "${workflow_disable_relaunch_option}" == "TRUE" ]]; then
+        log_status "Automatic relaunch is disabled; exiting without discovery/patching."
+        write_status "Inactive: Outside ScheduleWorkflowActive; automatic relaunch disabled."
+        exit_clean
+    fi
+
+    local next_epoch next_auto_launch
+    next_epoch=$(next_schedule_workflow_active_start_epoch "${now_epoch}")
+    # Avoid LaunchDaemon spin if the next window is moments away.
+    if (( next_epoch - now_epoch < 300 )); then
+        next_epoch=$(clamp_epoch_to_schedule_workflow_active $(( now_epoch + 300 )))
+    fi
+    next_auto_launch=$(date -r "${next_epoch}" +"${timestamp_format}")
+    defaults write "${appAutoPatchLocalPLIST}" NextAutoLaunch -date "${next_auto_launch}"
+    log_status "NextAutoLaunch set to next ScheduleWorkflowActive window start: ${next_auto_launch}"
+    write_status "Pending: Outside ScheduleWorkflowActive; next window ${next_auto_launch}."
+    log_exit "AAP is scheduled to automatically relaunch at: ${next_auto_launch}"
+    exit_clean
+}
+
 set_auto_launch_deferral() {
     log_verbose  "deferralNextLaunch is: ${deferral_timer_minutes}"
     local deferral_timestamp
     deferral_timestamp=$(( $(date +%s) + deferral_timer_minutes * 60 ))
+    local original_deferral_timestamp="${deferral_timestamp}"
+    deferral_timestamp=$(clamp_epoch_to_schedule_workflow_active "${deferral_timestamp}")
+    if [[ "${deferral_timestamp}" != "${original_deferral_timestamp}" ]]; then
+        log_notice "Deferral relaunch clamped into ScheduleWorkflowActive (was $(date -r "${original_deferral_timestamp}" +"${timestamp_format}"))."
+    fi
     local next_auto_launch
     next_auto_launch=$(date -r $deferral_timestamp +"$timestamp_format")
     defaults write "${appAutoPatchLocalPLIST}" NextAutoLaunch -date "${next_auto_launch}"
@@ -4067,7 +4345,14 @@ set_auto_launch_deferral() {
 set_auto_launch_monthly_cadence() {
     log_verbose  "deferralNextLaunch is: ${next_nth_weekday}"
     fixed_input="${next_nth_weekday/:/ }"
-    next_nth_weekday_for_defaults="$(date -j -f "%Y-%m-%d %H:%M:%S" "$fixed_input" +"$timestamp_format")"
+    local cadence_epoch original_cadence_epoch
+    cadence_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$fixed_input" +%s)
+    original_cadence_epoch="${cadence_epoch}"
+    cadence_epoch=$(clamp_epoch_to_schedule_workflow_active "${cadence_epoch}")
+    if [[ "${cadence_epoch}" != "${original_cadence_epoch}" ]]; then
+        log_notice "Monthly cadence relaunch clamped into ScheduleWorkflowActive (was $(date -r "${original_cadence_epoch}" +"${timestamp_format}"))."
+    fi
+    next_nth_weekday_for_defaults="$(date -r "${cadence_epoch}" +"$timestamp_format")"
     defaults write "${appAutoPatchLocalPLIST}" NextAutoLaunch -date "${next_nth_weekday_for_defaults}"
     log_exit "AAP is scheduled to automatically relaunch at: ${next_nth_weekday_for_defaults}"
     exit_clean

--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -25,8 +25,8 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
 scriptVersion="3.7.0"
-scriptDate="2026/08/08"
-scriptBuild="3.7.0.2608081505"
+scriptDate="2026/08/09"
+scriptBuild="3.7.0.2608091230"
 scriptFunctionalName="App Auto-Patch"
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 autoload -Uz is-at-least
@@ -70,6 +70,8 @@ echo "
     [--schedule-workflow-active=DAY:hh:mm-hh:mm,...]
     [--schedule-workflow-active-respect-hard-deadline]
     [--schedule-workflow-active-respect-hard-deadline-off]
+    [--schedule-workflow-active-silent-outside]
+    [--schedule-workflow-active-silent-outside-off]
 
     Deferral Deadline COUNT Options:
     [--deadline-count-focus=number]
@@ -175,6 +177,7 @@ echo "
     <key>WorkflowDisableRelaunch</key> <true/> | <false/>
     <key>ScheduleWorkflowActive</key> <string>MON:17:00-23:59,TUE:17:00-23:59,...</string>
     <key>ScheduleWorkflowActiveRespectHardDeadline</key> <true/> | <false/>
+    <key>ScheduleWorkflowActiveSilentOutside</key> <true/> | <false/>
     <key>DiscoveryFrequency</key> <integer>hours</integer>
     <key>WorkflowInstallNowPatchingStatusAction</key> <string>NEVER | ALWAYS | SUCCESS</string>
     <key>ZoomCallActiveCheck</key> <true/> | <false/>
@@ -319,10 +322,14 @@ set_defaults() {
     workflow_install_now_patching_status_action_option="SUCCESS" # MDM Enabled - Determines what happens when  NEVER | ALWAYS | SUCCESS 
 
     # ScheduleWorkflowActive (#166) - SUPER-compatible DAY:hh:mm-hh:mm windows. Empty/unset = always active.
-    # Local Mac timezone; same-day ranges only. Outside a window: reschedule NextAutoLaunch to next window start.
+    # Local Mac timezone; same-day ranges only. Outside a window: reschedule NextAutoLaunch to next window start
+    # (or, if ScheduleWorkflowActiveSilentOutside is true, discover + silently patch closed apps only).
     schedule_workflow_active_option="" # MDM Enabled
     # Empty until prefs resolve; managed/CLI/local then normalize to FALSE (default: hard deadline bypasses window) or TRUE.
     schedule_workflow_active_respect_hard_deadline_option="" # MDM Enabled
+    # Empty until prefs resolve; default FALSE = outside window exits. TRUE = closed-apps-only silent path outside window.
+    schedule_workflow_active_silent_outside_option="" # MDM Enabled
+    schedule_workflow_active_silent_outside_active="FALSE" # runtime flag set by enforce_schedule_workflow_active
     typeset -ga schedule_workflow_active_windows # populated by manage_parameter_options: "dow:startmin:endmin"
 
     UnattendedExit="FALSE" # MDM Enabled
@@ -1010,6 +1017,12 @@ get_options() {
             --schedule-workflow-active-respect-hard-deadline-off)
                 schedule_workflow_active_respect_hard_deadline_option="FALSE"
             ;;
+            --schedule-workflow-active-silent-outside)
+                schedule_workflow_active_silent_outside_option="TRUE"
+            ;;
+            --schedule-workflow-active-silent-outside-off)
+                schedule_workflow_active_silent_outside_option="FALSE"
+            ;;
             --webhook-feature-off)
                 webhook_feature_option="FALSE"
             ;;
@@ -1183,6 +1196,8 @@ get_preferences() {
         schedule_workflow_active_managed=$(defaults read "${appAutoPatchManagedPLIST}" ScheduleWorkflowActive 2>/dev/null)
         local schedule_workflow_active_respect_hard_deadline_managed
         schedule_workflow_active_respect_hard_deadline_managed=$(defaults read "${appAutoPatchManagedPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null)
+        local schedule_workflow_active_silent_outside_managed
+        schedule_workflow_active_silent_outside_managed=$(defaults read "${appAutoPatchManagedPLIST}" ScheduleWorkflowActiveSilentOutside 2>/dev/null)
         local webhook_feature_managed
         webhook_feature_managed=$(defaults read "${appAutoPatchManagedPLIST}" WebhookFeature 2> /dev/null)
         local webhook_url_slack_managed
@@ -1325,6 +1340,8 @@ get_preferences() {
         schedule_workflow_active_local=$(defaults read "${appAutoPatchLocalPLIST}" ScheduleWorkflowActive 2>/dev/null)
         local schedule_workflow_active_respect_hard_deadline_local
         schedule_workflow_active_respect_hard_deadline_local=$(defaults read "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null)
+        local schedule_workflow_active_silent_outside_local
+        schedule_workflow_active_silent_outside_local=$(defaults read "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveSilentOutside 2>/dev/null)
         local webhook_feature_local
         webhook_feature_local=$(defaults read "${appAutoPatchLocalPLIST}" WebhookFeature 2> /dev/null)
         local webhook_url_slack_local
@@ -1455,6 +1472,8 @@ get_preferences() {
     { [[ -z "${schedule_workflow_active_managed}" ]] && [[ -z "${schedule_workflow_active_option}" ]] && [[ -n "${schedule_workflow_active_local}" ]]; } && schedule_workflow_active_option="${schedule_workflow_active_local}"
     [[ -n "${schedule_workflow_active_respect_hard_deadline_managed}" ]] && schedule_workflow_active_respect_hard_deadline_option="${schedule_workflow_active_respect_hard_deadline_managed}"
     { [[ -z "${schedule_workflow_active_respect_hard_deadline_managed}" ]] && [[ -z "${schedule_workflow_active_respect_hard_deadline_option}" ]] && [[ -n "${schedule_workflow_active_respect_hard_deadline_local}" ]]; } && schedule_workflow_active_respect_hard_deadline_option="${schedule_workflow_active_respect_hard_deadline_local}"
+    [[ -n "${schedule_workflow_active_silent_outside_managed}" ]] && schedule_workflow_active_silent_outside_option="${schedule_workflow_active_silent_outside_managed}"
+    { [[ -z "${schedule_workflow_active_silent_outside_managed}" ]] && [[ -z "${schedule_workflow_active_silent_outside_option}" ]] && [[ -n "${schedule_workflow_active_silent_outside_local}" ]]; } && schedule_workflow_active_silent_outside_option="${schedule_workflow_active_silent_outside_local}"
     [[ -n "${webhook_feature_managed}" ]] && webhook_feature_option="${webhook_feature_managed}"
     { [[ -z "${webhook_feature_managed}" ]] && [[ -z "${webhook_feature_option}" ]] && [[ -n "${webhook_feature_local}" ]]; } && webhook_feature_option="${webhook_feature_local}"
     [[ -n "${webhook_url_slack_managed}" ]] && webhook_url_slack_option="${webhook_url_slack_managed}"
@@ -1602,6 +1621,7 @@ get_preferences() {
     log_verbose "WorkflowDisableRelaunch: $workflow_disable_relaunch_option"
     log_verbose "ScheduleWorkflowActive: ${schedule_workflow_active_option:-<unset>}"
     log_verbose "ScheduleWorkflowActiveRespectHardDeadline: ${schedule_workflow_active_respect_hard_deadline_option:-<unset>}"
+    log_verbose "ScheduleWorkflowActiveSilentOutside: ${schedule_workflow_active_silent_outside_option:-<unset>}"
     log_verbose "WebhookFeature: $webhook_feature_option"
     log_verbose "WebhookURLSlack: $webhook_url_slack_option"
     log_verbose "WebhookURLTeams: $webhook_url_teams_option"
@@ -2132,6 +2152,16 @@ manage_parameter_options() {
         defaults delete "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveRespectHardDeadline 2>/dev/null
     fi
     log_verbose "schedule_workflow_active_respect_hard_deadline_option is: ${schedule_workflow_active_respect_hard_deadline_option}"
+
+    # Manage ScheduleWorkflowActiveSilentOutside (default FALSE = outside window exits; TRUE = closed-apps-only silent path).
+    if [[ "${schedule_workflow_active_silent_outside_option}" -eq 1 ]] || [[ "${schedule_workflow_active_silent_outside_option}" == "TRUE" ]]; then
+        schedule_workflow_active_silent_outside_option="TRUE"
+        defaults write "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveSilentOutside -bool true
+    else
+        schedule_workflow_active_silent_outside_option="FALSE"
+        defaults delete "${appAutoPatchLocalPLIST}" ScheduleWorkflowActiveSilentOutside 2>/dev/null
+    fi
+    log_verbose "schedule_workflow_active_silent_outside_option is: ${schedule_workflow_active_silent_outside_option}"
     
     # Manage ${zoom_call_active_check_option} and save to ${appAutoPatchLocalPLIST}.
     if [[ "${zoom_call_active_check_option}" -eq 1 ]] || [[ "${zoom_call_active_check_option}" == "TRUE" ]]; then
@@ -4280,9 +4310,36 @@ is_hard_deadline_due_lightweight() {
     return 1
 }
 
-# Early gate: outside ScheduleWorkflowActive, reschedule to next window start and exit cleanly.
+# Write NextAutoLaunch to the next ScheduleWorkflowActive window start and exit cleanly.
+schedule_workflow_active_set_next_window_and_exit() {
+    local status_message="${1:-Outside ScheduleWorkflowActive}"
+    local now_epoch next_epoch next_auto_launch
+    now_epoch=$(date +%s)
+
+    if [[ "${workflow_disable_relaunch_option}" == "TRUE" ]]; then
+        log_status "Automatic relaunch is disabled; exiting without discovery/patching."
+        write_status "Inactive: ${status_message}; automatic relaunch disabled."
+        exit_clean
+    fi
+
+    next_epoch=$(next_schedule_workflow_active_start_epoch "${now_epoch}")
+    # Avoid LaunchDaemon spin if the next window is moments away.
+    if (( next_epoch - now_epoch < 300 )); then
+        next_epoch=$(clamp_epoch_to_schedule_workflow_active $(( now_epoch + 300 )))
+    fi
+    next_auto_launch=$(date -r "${next_epoch}" +"${timestamp_format}")
+    defaults write "${appAutoPatchLocalPLIST}" NextAutoLaunch -date "${next_auto_launch}"
+    log_status "NextAutoLaunch set to next ScheduleWorkflowActive window start: ${next_auto_launch}"
+    write_status "Pending: ${status_message}; next window ${next_auto_launch}."
+    log_exit "AAP is scheduled to automatically relaunch at: ${next_auto_launch}"
+    exit_clean
+}
+
+# Early gate: outside ScheduleWorkflowActive, either continue silent closed-app patching
+# (ScheduleWorkflowActiveSilentOutside) or reschedule to next window start and exit cleanly.
 # Bypassed by install-now / preview-deferral-dialog, and by overdue hard deadline unless RespectHardDeadline is TRUE.
 enforce_schedule_workflow_active() {
+    schedule_workflow_active_silent_outside_active="FALSE"
     if [[ ${#schedule_workflow_active_windows[@]} -eq 0 ]]; then
         return 0
     fi
@@ -4306,24 +4363,14 @@ enforce_schedule_workflow_active() {
 
     log_status "Outside ScheduleWorkflowActive window (${schedule_workflow_active_option})."
 
-    if [[ "${workflow_disable_relaunch_option}" == "TRUE" ]]; then
-        log_status "Automatic relaunch is disabled; exiting without discovery/patching."
-        write_status "Inactive: Outside ScheduleWorkflowActive; automatic relaunch disabled."
-        exit_clean
+    if [[ "${schedule_workflow_active_silent_outside_option}" == "TRUE" ]]; then
+        schedule_workflow_active_silent_outside_active="TRUE"
+        log_status "ScheduleWorkflowActiveSilentOutside enabled; continuing with discovery and closed-app silent patching only (no dialogs)."
+        write_status "Running: Outside ScheduleWorkflowActive; silent closed-app patching."
+        return 0
     fi
 
-    local next_epoch next_auto_launch
-    next_epoch=$(next_schedule_workflow_active_start_epoch "${now_epoch}")
-    # Avoid LaunchDaemon spin if the next window is moments away.
-    if (( next_epoch - now_epoch < 300 )); then
-        next_epoch=$(clamp_epoch_to_schedule_workflow_active $(( now_epoch + 300 )))
-    fi
-    next_auto_launch=$(date -r "${next_epoch}" +"${timestamp_format}")
-    defaults write "${appAutoPatchLocalPLIST}" NextAutoLaunch -date "${next_auto_launch}"
-    log_status "NextAutoLaunch set to next ScheduleWorkflowActive window start: ${next_auto_launch}"
-    write_status "Pending: Outside ScheduleWorkflowActive; next window ${next_auto_launch}."
-    log_exit "AAP is scheduled to automatically relaunch at: ${next_auto_launch}"
-    exit_clean
+    schedule_workflow_active_set_next_window_and_exit "Outside ScheduleWorkflowActive"
 }
 
 set_auto_launch_deferral() {
@@ -7537,6 +7584,47 @@ main() {
     for label in $queuedLabelsArray; do
         countOfElementsArray+=($label)
     done
+
+    # Outside ScheduleWorkflowActive with SilentOutside: discovery already ran; patch closed apps
+    # only with no dialogs. Remaining open/blocked apps wait for the next window.
+    if [[ "${schedule_workflow_active_silent_outside_active}" == "TRUE" ]]; then
+        if [[ "${WorkflowStageUpdatesOption}" == "TRUE" ]] && [[ ${#countOfElementsArray[@]} -gt 0 ]]; then
+            workflow_stage_updates
+        fi
+        if [[ ${#countOfElementsArray[@]} -gt 0 ]]; then
+            log_info "ScheduleWorkflowActiveSilentOutside: silently patching closed apps only..."
+            workflow_silent_patch_closed_apps
+        fi
+        if [[ ${#countOfElementsArray[@]} -gt 0 ]]; then
+            log_status "Outside schedule window: ${#countOfElementsArray[@]} open/blocked app(s) remain; deferring interactive install to next ScheduleWorkflowActive window."
+            schedule_workflow_active_set_next_window_and_exit "Outside ScheduleWorkflowActive; open apps remain after silent closed-app patch"
+        fi
+        log_info "Outside schedule window: no apps remain after silent closed-app patch (or none were due)."
+        defaults write "${appAutoPatchLocalPLIST}" AAPPatchingCompletionStatus -bool true
+        timestamp="$(date +$timestamp_format)"
+        defaults write "${appAutoPatchLocalPLIST}" AAPPatchingCompleteDate -date "$timestamp"
+        check_webhook
+        if [[ "${workflow_disable_relaunch_option}" == "TRUE" ]]; then
+            log_aap "Status: Patching Complete and Automatic Relaunch is disabled. Exiting."
+            log_status "Inactive: Patching Complete and Automatic Relaunch is disabled."
+            /usr/libexec/PlistBuddy -c "Add :NextAutoLaunch string FALSE" "${appAutoPatchLocalPLIST}.plist" 2> /dev/null
+            { sleep 5; launchctl bootstrap system "/Library/LaunchDaemons/${appAutoPatchLaunchDaemonLabel}.plist"; } &
+            disown
+            exit_clean
+        else
+            if [[ "${monthly_patching_cadence_enabled:l}" == "true" ]] \
+            || [[ "${monthly_patching_cadence_enabled}" == "1" ]]; then
+                log_aap "Monthly Patching Cadence Enabled: Calculating next launch date"
+                next_nth_weekday=$(next_nth_weekday_datetime ${monthly_patching_cadence_weekday_index} ${monthly_patching_cadence_ordinal_value} "${monthly_patching_cadence_start_time}")
+                log_notice "Will auto launch on ${next_nth_weekday}"
+                set_auto_launch_monthly_cadence
+            else
+                deferral_timer_minutes="${deferral_timer_workflow_relaunch_minutes}"
+                log_notice "Will auto launch in ${deferral_timer_minutes} minutes."
+                set_auto_launch_deferral
+            fi
+        fi
+    fi
 
     # Stage installers before the silent background-patch pass below, so each queued app is
     # downloaded at most once (closed apps then install from the staged copy; open/blocked apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This is a user-facing summary of App Auto-Patch releases: what changed, what's n
 
 **New Features**
 
+- **Schedule Workflow Active** — Restrict discovery, dialogs, and patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm` format). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start — no discovery/dialogs/Installomator. Deferral and monthly-cadence relaunches are clamped into the next allowed window. Install-now / preview-deferral-dialog bypass the schedule. Overdue hard deadlines bypass by default; set `ScheduleWorkflowActiveRespectHardDeadline` to `true` for strict “never outside hours” mode. (#166)
+	- Managed Preference Key: `<key>ScheduleWorkflowActive</key>` `<string>MON:17:00-23:59,TUE:17:00-23:59,...</string>` — empty/unset = always active
+	- Managed Preference Key: `<key>ScheduleWorkflowActiveRespectHardDeadline</key>` `<true/>` | `<false/>` — default: `false` (hard deadline bypasses the window)
+	- CLI: `--schedule-workflow-active=...` / `--schedule-workflow-active-respect-hard-deadline` / `--schedule-workflow-active-respect-hard-deadline-off`
 - **Pre/Post Patch Scripts** — Run a managed, root-owned script once before and/or after Installomator installations (e.g. `jamf recon`). Scripts must live under `/Library/Management/AppAutoPatch/Hooks/`, cannot be symlinks, and must not be group/world-writable. Managed preferences only — never CLI or local prefs, never `eval`'d. (#156)
 	- Managed Preference Key: `<key>PrePatchScript</key>` `<string>/Library/Management/AppAutoPatch/Hooks/pre.sh</string>`
 	- Managed Preference Key: `<key>PostPatchScript</key>` `<string>/Library/Management/AppAutoPatch/Hooks/post.sh</string>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ This is a user-facing summary of App Auto-Patch releases: what changed, what's n
 
 **New Features**
 
-- **Schedule Workflow Active** — Restrict discovery, dialogs, and patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm` format). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start — no discovery/dialogs/Installomator. Deferral and monthly-cadence relaunches are clamped into the next allowed window. Install-now / preview-deferral-dialog bypass the schedule. Overdue hard deadlines bypass by default; set `ScheduleWorkflowActiveRespectHardDeadline` to `true` for strict “never outside hours” mode. (#166)
+- **Schedule Workflow Active** — Restrict discovery, dialogs, and patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm` format). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start — no discovery/dialogs/Installomator — unless Silent Outside is enabled. Deferral and monthly-cadence relaunches are clamped into the next allowed window. Install-now / preview-deferral-dialog bypass the schedule. Overdue hard deadlines bypass by default; set `ScheduleWorkflowActiveRespectHardDeadline` to `true` for strict “never outside hours” mode. (#166)
 	- Managed Preference Key: `<key>ScheduleWorkflowActive</key>` `<string>MON:17:00-23:59,TUE:17:00-23:59,...</string>` — empty/unset = always active
 	- Managed Preference Key: `<key>ScheduleWorkflowActiveRespectHardDeadline</key>` `<true/>` | `<false/>` — default: `false` (hard deadline bypasses the window)
-	- CLI: `--schedule-workflow-active=...` / `--schedule-workflow-active-respect-hard-deadline` / `--schedule-workflow-active-respect-hard-deadline-off`
+	- Managed Preference Key: `<key>ScheduleWorkflowActiveSilentOutside</key>` `<true/>` | `<false/>` — default: `false`. When `true`, outside a window AAP still runs discovery and silently patches **closed apps only** (no dialogs, even if InteractiveMode is 1/2). Open/blocked apps stay queued and wait for the next window.
+	- CLI: `--schedule-workflow-active=...` / `--schedule-workflow-active-respect-hard-deadline` / `-off` / `--schedule-workflow-active-silent-outside` / `-off`
 - **Pre/Post Patch Scripts** — Run a managed, root-owned script once before and/or after Installomator installations (e.g. `jamf recon`). Scripts must live under `/Library/Management/AppAutoPatch/Hooks/`, cannot be symlinks, and must not be group/world-writable. Managed preferences only — never CLI or local prefs, never `eval`'d. (#156)
 	- Managed Preference Key: `<key>PrePatchScript</key>` `<string>/Library/Management/AppAutoPatch/Hooks/pre.sh</string>`
 	- Managed Preference Key: `<key>PostPatchScript</key>` `<string>/Library/Management/AppAutoPatch/Hooks/post.sh</string>`

--- a/CHANGELOG_DETAIL.md
+++ b/CHANGELOG_DETAIL.md
@@ -3,6 +3,18 @@
 # Version 3
 
 ## Version 3.7.0
+### 09-Aug-2026 (1) - Build 3.7.0.2608091230
+- [#166](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166): `ScheduleWorkflowActive` (SUPER-compatible workflow schedule windows), including Silent Outside, brought onto the 3.7.0 release line:
+	- Managed key `ScheduleWorkflowActive` = `DAY:hh:mm-hh:mm,...` (`MON`–`SUN`, 24-hour, comma-separated). Empty/unset = always active (unchanged behavior). Local Mac timezone; same-day ranges only (overnight = two windows)
+	- Early gate after prefs/validation + install-now flags, before Jamf restart / network / discovery: outside a window → set `NextAutoLaunch` to next window start (with a small bump if &lt; ~5 minutes away) and `exit_clean` — no discovery, dialogs, Installomator, or webhooks — unless Silent Outside is enabled
+	- Bypass: `--workflow-install-now`, `--workflow-install-now-silent`, `--preview-deferral-dialog`
+	- Default: overdue hard deadline (days or count) bypasses the window via a lightweight read-only check (does not mutate deadline counters / does not sleep). Optional `ScheduleWorkflowActiveRespectHardDeadline` (`true` = even hard deadlines wait for the next window). Soft/focus deadlines still respect the window
+	- `ScheduleWorkflowActiveSilentOutside` (default `false`): when `true` and outside a window, continue with discovery and `workflow_silent_patch_closed_apps` only — no dialogs even if InteractiveMode is 1/2. Open/blocked apps remaining after that pass are deferred to the next window start. Independent of `WorkflowBackgroundPatchClosedApps` for this outside-window path
+	- All `NextAutoLaunch` writers (`set_auto_launch_deferral`, `set_auto_launch_monthly_cadence`) clamp into the next allowed window when a schedule is configured
+	- Invalid schedule string fails startup validation (`option_error`)
+	- CLI for testing: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off` / `--schedule-workflow-active-silent-outside` / `-off`
+	- iMazing + Jamf manifests and All-Options examples updated
+
 ### 08-Aug-2026 (3) - Build 3.7.0.2608081505
 - [#254](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/254): fixed ignored labels being disregarded, and the local preference plist intermittently reading back blank. Both were reproducible from a single verbose log in which discovery issued 1,159 `PlistBuddy` writes, logged zero ignore matches, and then queued an explicitly ignored app:
 	- **`IFS` leak out of discovery.** The label-fragment parser sets `IFS=$'\n'` and never restored it. Everything downstream in `main()` then ran with a newline `IFS`: the `" ${ignoredLabelsArray[*]} "` substring test could only ever match the first and last elements, the `$(... | tr '\n' ' ')` dedupe steps collapsed each label list into one whitespace-padded element, and `${labelsArray:|ignoredLabelsArray}` therefore compared `"firefox "` against `"firefox"` and removed nothing. Runs that skipped discovery (`DiscoveryFrequency`) never set `IFS` and behaved correctly, which is why the failure appeared to alternate between runs. `IFS` is now saved before the parser and restored the moment the fragment loops finish
@@ -12,17 +24,6 @@
 	- **Required labels are protected from wildcards.** The wildcard expansion skipped labels listed as Optional but not those listed as Required, so `IgnoredLabels="*"` (or any wildcard covering them) put required apps into the ignored list and `${labelsArray:|ignoredLabelsArray}` then dropped them from the queue - required apps were never patched. `RequiredLabels` is now checked alongside `OptionalLabels`, against the in-memory array since `RequiredLabels` hasn't been written to the plist yet at that point
 	- **Hardened local preference reads.** New `read_local_preference()` reads a key with `defaults` and falls back to `PlistBuddy` when the value comes back empty, normalising `true`/`false` to `1`/`0` so existing comparisons are unaffected. `check_completion_status()` uses it for `AAPPatchingCompletionStatus` / `AAPPatchingStartDate`, validates the start date against `^\d{4}-\d{2}-\d{2}` (trimming a full timestamp to the date), and falls back to the computed patch week start date - logging an error and rewriting the key - rather than handing an empty string to `strftime`
 	- **Label list parsing.** New `parse_labels_option()` normalises a labels preference into an array, stripping the parentheses, quotes, and trailing commas that `defaults read` emits for array-typed preferences. Previously those became label names in their own right, visible in the log as `Required labels: ( )`
-
-### 08-Aug-2026 (2b) - Build 3.7.0.2608081234
-- [#166](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166): `ScheduleWorkflowActive` (SUPER-compatible workflow schedule windows):
-	- Managed key `ScheduleWorkflowActive` = `DAY:hh:mm-hh:mm,...` (`MON`–`SUN`, 24-hour, comma-separated). Empty/unset = always active (unchanged behavior). Local Mac timezone; same-day ranges only (overnight = two windows)
-	- Early gate after prefs/validation + install-now flags, before Jamf restart / network / discovery: outside a window → set `NextAutoLaunch` to next window start (with a small bump if &lt; ~5 minutes away) and `exit_clean` — no discovery, dialogs, Installomator, or webhooks
-	- Bypass: `--workflow-install-now`, `--workflow-install-now-silent`, `--preview-deferral-dialog`
-	- Default: overdue hard deadline (days or count) bypasses the window via a lightweight read-only check (does not mutate deadline counters / does not sleep). Optional `ScheduleWorkflowActiveRespectHardDeadline` (`true` = even hard deadlines wait for the next window). Soft/focus deadlines still respect the window
-	- All `NextAutoLaunch` writers (`set_auto_launch_deferral`, `set_auto_launch_monthly_cadence`) clamp into the next allowed window when a schedule is configured
-	- Invalid schedule string fails startup validation (`option_error`)
-	- CLI for testing: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off`
-	- iMazing + Jamf manifests and All-Options examples updated
 
 ### 08-Aug-2026 (2) - Build 3.7.0.2608081108
 - [#156](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/156): optional pre/post patch script hooks for workflows like `jamf recon` or fixing `.app` ownership after Installomator installs. Security-hardened by design:

--- a/CHANGELOG_DETAIL.md
+++ b/CHANGELOG_DETAIL.md
@@ -13,6 +13,17 @@
 	- **Hardened local preference reads.** New `read_local_preference()` reads a key with `defaults` and falls back to `PlistBuddy` when the value comes back empty, normalising `true`/`false` to `1`/`0` so existing comparisons are unaffected. `check_completion_status()` uses it for `AAPPatchingCompletionStatus` / `AAPPatchingStartDate`, validates the start date against `^\d{4}-\d{2}-\d{2}` (trimming a full timestamp to the date), and falls back to the computed patch week start date - logging an error and rewriting the key - rather than handing an empty string to `strftime`
 	- **Label list parsing.** New `parse_labels_option()` normalises a labels preference into an array, stripping the parentheses, quotes, and trailing commas that `defaults read` emits for array-typed preferences. Previously those became label names in their own right, visible in the log as `Required labels: ( )`
 
+### 08-Aug-2026 (2b) - Build 3.7.0.2608081234
+- [#166](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166): `ScheduleWorkflowActive` (SUPER-compatible workflow schedule windows):
+	- Managed key `ScheduleWorkflowActive` = `DAY:hh:mm-hh:mm,...` (`MON`–`SUN`, 24-hour, comma-separated). Empty/unset = always active (unchanged behavior). Local Mac timezone; same-day ranges only (overnight = two windows)
+	- Early gate after prefs/validation + install-now flags, before Jamf restart / network / discovery: outside a window → set `NextAutoLaunch` to next window start (with a small bump if &lt; ~5 minutes away) and `exit_clean` — no discovery, dialogs, Installomator, or webhooks
+	- Bypass: `--workflow-install-now`, `--workflow-install-now-silent`, `--preview-deferral-dialog`
+	- Default: overdue hard deadline (days or count) bypasses the window via a lightweight read-only check (does not mutate deadline counters / does not sleep). Optional `ScheduleWorkflowActiveRespectHardDeadline` (`true` = even hard deadlines wait for the next window). Soft/focus deadlines still respect the window
+	- All `NextAutoLaunch` writers (`set_auto_launch_deferral`, `set_auto_launch_monthly_cadence`) clamp into the next allowed window when a schedule is configured
+	- Invalid schedule string fails startup validation (`option_error`)
+	- CLI for testing: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off`
+	- iMazing + Jamf manifests and All-Options examples updated
+
 ### 08-Aug-2026 (2) - Build 3.7.0.2608081108
 - [#156](https://github.com/App-Auto-Patch/App-Auto-Patch/issues/156): optional pre/post patch script hooks for workflows like `jamf recon` or fixing `.app` ownership after Installomator installs. Security-hardened by design:
 	- Managed preferences only (`PrePatchScript` / `PostPatchScript`) - never CLI, never written to / read from the local preference plist, never `eval`'d or run via `bash -c`

--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ App Auto-Patch is a MDM-agnostic Third Party Patching tool that combines local a
 App Auto-Patch simplifies the process of inventorying installed applications and patching them, for any MDM. For those using Jamf Pro, this helps eliminate the need to create multiple Smart Groups, Policies, Patch Management Titles, etc., within Jamf Pro. It provides an easy way to keep end users' applications updated with minimal effort.
 
 ## New features/Specific Changes in 3.7.0
-- **Schedule Workflow Active** — Restrict discovery/dialogs/patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm`). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start. Deferrals and monthly cadence relaunches are clamped into the schedule. Install-now / preview bypass; overdue hard deadlines bypass by default. (#166)
+- **Schedule Workflow Active** — Restrict discovery/dialogs/patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm`). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start unless Silent Outside is enabled. Deferrals and monthly cadence relaunches are clamped into the schedule. Install-now / preview bypass; overdue hard deadlines bypass by default. (#166)
 	- Managed Preference Key: `<key>ScheduleWorkflowActive</key>` `<string>MON:17:00-23:59,...</string>`
 	- Managed Preference Key: `<key>ScheduleWorkflowActiveRespectHardDeadline</key>` `<true/>` | `<false/>` (default `false`)
-	- CLI: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off`
+	- Managed Preference Key: `<key>ScheduleWorkflowActiveSilentOutside</key>` `<true/>` | `<false/>` (default `false`) — outside window: discovery + closed-apps-only silent patch; no dialogs; open apps wait for next window
+	- CLI: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off` / `--schedule-workflow-active-silent-outside` / `-off`
 - **Pre/Post Patch Scripts** — Run a managed, root-owned script once before and/or after Installomator installations (e.g. `jamf recon`). Scripts must live under `/Library/Management/AppAutoPatch/Hooks/`, cannot be symlinks, and must not be group/world-writable. Managed preferences only — never CLI or local prefs, never `eval`'d. (#156)
 	- Managed Preference Key: `<key>PrePatchScript</key>` / `<key>PostPatchScript</key>`
 	- Managed Preference Key: `<key>PrePatchScriptFailAction</key>` `ABORT`|`CONTINUE` (default `ABORT`)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ App Auto-Patch is a MDM-agnostic Third Party Patching tool that combines local a
 App Auto-Patch simplifies the process of inventorying installed applications and patching them, for any MDM. For those using Jamf Pro, this helps eliminate the need to create multiple Smart Groups, Policies, Patch Management Titles, etc., within Jamf Pro. It provides an easy way to keep end users' applications updated with minimal effort.
 
 ## New features/Specific Changes in 3.7.0
+- **Schedule Workflow Active** — Restrict discovery/dialogs/patching to weekday time windows (SUPER-compatible `DAY:hh:mm-hh:mm`). Outside a window, AAP only reschedules `NextAutoLaunch` to the next window start. Deferrals and monthly cadence relaunches are clamped into the schedule. Install-now / preview bypass; overdue hard deadlines bypass by default. (#166)
+	- Managed Preference Key: `<key>ScheduleWorkflowActive</key>` `<string>MON:17:00-23:59,...</string>`
+	- Managed Preference Key: `<key>ScheduleWorkflowActiveRespectHardDeadline</key>` `<true/>` | `<false/>` (default `false`)
+	- CLI: `--schedule-workflow-active=` / `--schedule-workflow-active-respect-hard-deadline` / `-off`
 - **Pre/Post Patch Scripts** — Run a managed, root-owned script once before and/or after Installomator installations (e.g. `jamf recon`). Scripts must live under `/Library/Management/AppAutoPatch/Hooks/`, cannot be symlinks, and must not be group/world-writable. Managed preferences only — never CLI or local prefs, never `eval`'d. (#156)
 	- Managed Preference Key: `<key>PrePatchScript</key>` / `<key>PostPatchScript</key>`
 	- Managed Preference Key: `<key>PrePatchScriptFailAction</key>` `ABORT`|`CONTINUE` (default `ABORT`)

--- a/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.mobileconfig
+++ b/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.mobileconfig
@@ -127,6 +127,10 @@
 			<string>FALSE</string>
 			<key>WorkflowDisableRelaunch</key>
 			<string>FALSE</string>
+			<key>ScheduleWorkflowActive</key>
+			<string>MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59</string>
+			<key>ScheduleWorkflowActiveRespectHardDeadline</key>
+			<false/>
 			<key>WorkflowInstallNowPatchingStatusAction</key>
 			<string>SUCCESS</string>
 			<key>ZoomCallActiveCheck</key>

--- a/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.mobileconfig
+++ b/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.mobileconfig
@@ -131,6 +131,8 @@
 			<string>MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59</string>
 			<key>ScheduleWorkflowActiveRespectHardDeadline</key>
 			<false/>
+			<key>ScheduleWorkflowActiveSilentOutside</key>
+			<false/>
 			<key>WorkflowInstallNowPatchingStatusAction</key>
 			<string>SUCCESS</string>
 			<key>ZoomCallActiveCheck</key>

--- a/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.plist
+++ b/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.plist
@@ -114,6 +114,10 @@
 	<string>FALSE</string>
 	<key>WorkflowDisableRelaunch</key>
 	<string>FALSE</string>
+	<key>ScheduleWorkflowActive</key>
+	<string>MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59</string>
+	<key>ScheduleWorkflowActiveRespectHardDeadline</key>
+	<false/>
 	<key>WorkflowInstallNowPatchingStatusAction</key>
 	<string>SUCCESS</string>
 	<key>ZoomCallActiveCheck</key>

--- a/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.plist
+++ b/Resources/All-Options-Example-DO-NOT-DEPLOY-xyz.techitout.appAutoPatch.plist
@@ -118,6 +118,8 @@
 	<string>MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59</string>
 	<key>ScheduleWorkflowActiveRespectHardDeadline</key>
 	<false/>
+	<key>ScheduleWorkflowActiveSilentOutside</key>
+	<false/>
 	<key>WorkflowInstallNowPatchingStatusAction</key>
 	<string>SUCCESS</string>
 	<key>ZoomCallActiveCheck</key>

--- a/Resources/Manifests/xyz.techitout.appAutoPatch-manifest-jamf.json
+++ b/Resources/Manifests/xyz.techitout.appAutoPatch-manifest-jamf.json
@@ -1136,7 +1136,7 @@
         "ScheduleWorkflowActive": {
             "type": "string",
             "title": "Schedule Workflow Active",
-            "description": "Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching. Bypassed by install-now / preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.",
+            "description": "Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching unless ScheduleWorkflowActiveSilentOutside is true. Bypassed by install-now / preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.",
             "options": {
                 "inputAttributes": {
                     "placeholder": "MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59"
@@ -1162,6 +1162,19 @@
                 }
             ],
             "property_order": 197
+        },
+        "ScheduleWorkflowActiveSilentOutside": {
+            "type": "boolean",
+            "title": "Schedule Workflow Active Silent Outside",
+            "description": "When true and outside a ScheduleWorkflowActive window, AAP still runs discovery and silently patches closed apps only — no dialogs even if InteractiveMode is 1 or 2. Open or blocked apps remain queued and are deferred to the next window start. When false (default), outside a window AAP only reschedules NextAutoLaunch and exits.",
+            "default": false,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166"
+                }
+            ],
+            "property_order": 198
         },
         "WorkflowInstallNowPatchingStatusAction": {
             "type": "string",

--- a/Resources/Manifests/xyz.techitout.appAutoPatch-manifest-jamf.json
+++ b/Resources/Manifests/xyz.techitout.appAutoPatch-manifest-jamf.json
@@ -1133,6 +1133,36 @@
             ],
             "property_order": 195
         },
+        "ScheduleWorkflowActive": {
+            "type": "string",
+            "title": "Schedule Workflow Active",
+            "description": "Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching. Bypassed by install-now / preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.",
+            "options": {
+                "inputAttributes": {
+                    "placeholder": "MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59"
+                        }
+                    },
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166"
+                }
+            ],
+            "property_order": 196
+        },
+        "ScheduleWorkflowActiveRespectHardDeadline": {
+            "type": "boolean",
+            "title": "Schedule Workflow Active Respect Hard Deadline",
+            "description": "When true, even an overdue hard deadline (days or count) waits for the next ScheduleWorkflowActive window. When false (default), an overdue hard deadline bypasses the schedule window so mandatory installs are not delayed by days.",
+            "default": false,
+            "links": [
+                {
+                    "rel": "More information",
+                    "href": "https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166"
+                }
+            ],
+            "property_order": 197
+        },
         "WorkflowInstallNowPatchingStatusAction": {
             "type": "string",
             "title": "Workflow Install Now Patching Status Action",

--- a/Resources/Manifests/xyz.techitout.appAutoPatch-manifest.plist
+++ b/Resources/Manifests/xyz.techitout.appAutoPatch-manifest.plist
@@ -218,6 +218,7 @@ During a profile replacement, the system updates payloads with the same `Payload
 					<string>WorkflowDisableRelaunch</string>
 					<string>ScheduleWorkflowActive</string>
 					<string>ScheduleWorkflowActiveRespectHardDeadline</string>
+					<string>ScheduleWorkflowActiveSilentOutside</string>
 					<string>WorkflowInstallNowPatchingStatusAction</string>
 					<string>WorkflowStageUpdates</string>
 					<string>WorkflowBackgroundPatchClosedApps</string>
@@ -1394,7 +1395,7 @@ During a profile replacement, the system updates payloads with the same `Payload
 			<key>pfm_app_min</key>
 			<string>3.7.0</string>
 			<key>pfm_description</key>
-			<string>Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only — split overnight spans into two windows. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching. Local Mac timezone. Bypassed by --workflow-install-now / --workflow-install-now-silent / --preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.</string>
+			<string>Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only — split overnight spans into two windows. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching unless ScheduleWorkflowActiveSilentOutside is true. Local Mac timezone. Bypassed by --workflow-install-now / --workflow-install-now-silent / --preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.</string>
 			<key>pfm_description_reference</key>
 			<string>https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166</string>
 			<key>pfm_name</key>
@@ -1419,6 +1420,22 @@ During a profile replacement, the system updates payloads with the same `Payload
 			<string>ScheduleWorkflowActiveRespectHardDeadline</string>
 			<key>pfm_title</key>
 			<string>Schedule Workflow Active Respect Hard Deadline</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>3.7.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When true and outside a ScheduleWorkflowActive window, AAP still runs discovery and silently patches closed apps only — no dialogs even if InteractiveMode is 1 or 2. Open or blocked apps remain queued and are deferred to the next window start. When false (default), outside a window AAP only reschedules NextAutoLaunch and exits.</string>
+			<key>pfm_description_reference</key>
+			<string>https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166</string>
+			<key>pfm_name</key>
+			<string>ScheduleWorkflowActiveSilentOutside</string>
+			<key>pfm_title</key>
+			<string>Schedule Workflow Active Silent Outside</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Resources/Manifests/xyz.techitout.appAutoPatch-manifest.plist
+++ b/Resources/Manifests/xyz.techitout.appAutoPatch-manifest.plist
@@ -216,6 +216,8 @@ During a profile replacement, the system updates payloads with the same `Payload
 					<string>WebhookURLTeams</string>
 					<string>WorkflowDisableAppDiscovery</string>
 					<string>WorkflowDisableRelaunch</string>
+					<string>ScheduleWorkflowActive</string>
+					<string>ScheduleWorkflowActiveRespectHardDeadline</string>
 					<string>WorkflowInstallNowPatchingStatusAction</string>
 					<string>WorkflowStageUpdates</string>
 					<string>WorkflowBackgroundPatchClosedApps</string>
@@ -1387,6 +1389,38 @@ During a profile replacement, the system updates payloads with the same `Payload
 			<string>Disable Relaunch Workflow</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>3.7.0</string>
+			<key>pfm_description</key>
+			<string>Restrict App Auto-Patch discovery/dialogs/patching to specific weekday time windows (SUPER-compatible). Format: DAY:hh:mm-hh:mm, comma-separated, no spaces (MON-SUN, 24-hour). Multiple windows per day allowed. Same-day ranges only — split overnight spans into two windows. Empty/unset = always active. Outside a window, AAP reschedules NextAutoLaunch to the next window start and exits without patching. Local Mac timezone. Bypassed by --workflow-install-now / --workflow-install-now-silent / --preview-deferral-dialog. Overdue hard deadlines bypass the window by default unless ScheduleWorkflowActiveRespectHardDeadline is true.</string>
+			<key>pfm_description_reference</key>
+			<string>https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166</string>
+			<key>pfm_name</key>
+			<string>ScheduleWorkflowActive</string>
+			<key>pfm_title</key>
+			<string>Schedule Workflow Active</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>MON:17:00-23:59,TUE:17:00-23:59,WED:17:00-23:59,THU:17:00-23:59,FRI:17:00-23:59</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>3.7.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>When true, even an overdue hard deadline (days or count) waits for the next ScheduleWorkflowActive window. When false (default), an overdue hard deadline bypasses the schedule window so mandatory installs are not delayed by days.</string>
+			<key>pfm_description_reference</key>
+			<string>https://github.com/App-Auto-Patch/App-Auto-Patch/issues/166</string>
+			<key>pfm_name</key>
+			<string>ScheduleWorkflowActiveRespectHardDeadline</string>
+			<key>pfm_title</key>
+			<string>Schedule Workflow Active Respect Hard Deadline</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>


### PR DESCRIPTION
## Summary
- Ports `ScheduleWorkflowActive` and `ScheduleWorkflowActiveSilentOutside` from the 3.8.0 line onto the 3.7.0 release branch
- Keeps `scriptVersion` / `scriptBuild` / README / changelogs / manifest `pfm_app_min` on **3.7.0** (build `3.7.0.2608091230`)
- Leaves the existing `#254` IgnoredLabels fix intact on 3.7.0

## Test plan
- [x] Confirm `scriptVersion="3.7.0"` and `scriptBuild="3.7.0.2608091230"` in the script
- [ ] Confirm README / CHANGELOG have no 3.8.0 section and document `#166` under 3.7.0
- [ ] With `ScheduleWorkflowActive` set and outside a window (SilentOutside false): AAP reschedules `NextAutoLaunch` and exits without discovery/dialogs
- [ ] With `ScheduleWorkflowActiveSilentOutside=true` outside a window: discovery runs and closed apps patch silently; open apps defer to next window
- [ ] Install-now / preview-deferral-dialog still bypass the schedule
- [ ] Manifest keys for ScheduleWorkflow* show `pfm_app_min` 3.7.0


Made with [Cursor](https://cursor.com)