### PR TITLE
Honor IgnoreAppsInHomeFolder and stop deleting apps out of ~/Applications

### DIFF
--- a/App-Auto-Patch-via-Dialog.zsh
+++ b/App-Auto-Patch-via-Dialog.zsh
@@ -1389,6 +1389,29 @@ get_preferences() {
     { [[ -z "${convert_apps_in_home_folder_managed}" ]] && [[ -n "${convertAppsInHomeFolder}" ]] && [[ -n "${convert_apps_in_home_folder_local}" ]]; } && convertAppsInHomeFolder="${convert_apps_in_home_folder_local}"
     [[ -n "${ignore_apps_in_home_folder_managed}" ]] && ignoreAppsInHomeFolder="${ignore_apps_in_home_folder_managed}"
     { [[ -z "${ignore_apps_in_home_folder_managed}" ]] && [[ -n "${ignoreAppsInHomeFolder}" ]] && [[ -n "${ignore_apps_in_home_folder_local}" ]]; } && ignoreAppsInHomeFolder="${ignore_apps_in_home_folder_local}"
+
+    # Normalize the home-folder booleans. A configuration profile can deliver these as real
+    # booleans (<true/>), which `defaults read` returns as 1/0 - never the literal "TRUE" the
+    # discovery workflow compares against. Without this, a managed IgnoreAppsInHomeFolder=<true/>
+    # was silently ignored and ConvertAppsInHomeFolder kept deleting apps out of ~/Applications.
+    if [[ "${convertAppsInHomeFolder}" -eq 1 ]] || [[ "${convertAppsInHomeFolder:u}" == "TRUE" ]]; then
+        convertAppsInHomeFolder="TRUE"
+    else
+        convertAppsInHomeFolder="FALSE"
+    fi
+    if [[ "${ignoreAppsInHomeFolder}" -eq 1 ]] || [[ "${ignoreAppsInHomeFolder:u}" == "TRUE" ]]; then
+        ignoreAppsInHomeFolder="TRUE"
+    else
+        ignoreAppsInHomeFolder="FALSE"
+    fi
+
+    # Ignoring wins over converting: leaving a user-installed app alone is always recoverable,
+    # deleting it is not.
+    if [[ "${ignoreAppsInHomeFolder}" == "TRUE" ]] && [[ "${convertAppsInHomeFolder}" == "TRUE" ]]; then
+        log_verbose "Both IgnoreAppsInHomeFolder and ConvertAppsInHomeFolder are enabled, honoring Ignore and disabling Convert"
+        convertAppsInHomeFolder="FALSE"
+    fi
+
     [[ -n "${installomator_options_managed}" ]] && installomatorOptions="${installomator_options_managed}"
     { [[ -z "${installomator_options_managed}" ]] && [[ -n "${installomatorOptions}" ]] && [[ -n "${installomator_options_local}" ]]; } && installomatorOptions="${installomator_options_local}"
     
@@ -4622,14 +4645,14 @@ function PgetAppVersion() {
         elif ([[ "$applist" == *"/Applications/Edge Apps.localized/"* ]]); then
             log_info "App found in the Edge PWA app folder: $applist, ignoring"
             applist=""
+        elif ([[ "$applist" == *"/Users/"* && "$ignoreAppsInHomeFolder" == "TRUE" ]]); then
+            log_verbose "Ignoring user installed application: $applist"
+            applist=""
         elif ([[ "$applist" == *"/Users/"* && "$convertAppsInHomeFolder" == "TRUE" ]]); then
             log_verbose "App found in User directory: $applist, coverting to default directory"
             # Adding the label to the converted labels
             /usr/libexec/PlistBuddy -c "add \":ConvertedLabels:\" string \"${label_name}\"" "${appAutoPatchLocalPLIST}.plist"
             rm -rf $applist
-        elif ([[ "$applist" == *"/Users/"* && "$ignoreAppsInHomeFolder" == "TRUE" ]]); then
-            log_verbose "Ignoring user installed application: $applist"
-            applist=""
         fi
     fi
     

--- a/Resources/run-local.zsh
+++ b/Resources/run-local.zsh
@@ -1,0 +1,76 @@
+#!/bin/zsh --no-rcs
+
+# Run the working-copy App Auto-Patch script on this Mac, for development.
+#
+# AAP hardcodes its state under /Library/Management/AppAutoPatch and must run as root, so there is
+# no sandboxed mode - this really patches this Mac. What it gives you over calling the script by
+# hand is: it runs the repo copy (not the deployed /Library/Management one), it stops the
+# LaunchDaemon first so the deployed copy can't relaunch on top of you, and it defaults to verbose
+# logging with the relaunch workflow disabled.
+#
+#   sudo ./Resources/run-local.zsh                                        # normal interactive run
+#   sudo ./Resources/run-local.zsh --force-discovery                      # re-scan even if DiscoveryFrequency hasn't elapsed
+#   sudo ./Resources/run-local.zsh --interactiveMode=0 --workflow-install-now-silent
+#
+# Note: AAP has no discovery-only mode - discovery always feeds straight into patching. To watch
+# discovery without anything being installed, add every label you care about to --ignored-labels.
+#
+# Any other arguments are passed through to App-Auto-Patch-via-Dialog.zsh untouched.
+
+scriptDir="${0:A:h}"
+repoRoot="${scriptDir:h}"
+aapScript="${repoRoot}/App-Auto-Patch-via-Dialog.zsh"
+launchDaemonLabel="xyz.techitout.aap"
+launchDaemonPlist="/Library/LaunchDaemons/${launchDaemonLabel}.plist"
+
+if [[ $(id -u) -ne 0 ]]; then
+    print -u2 "Error: App Auto-Patch must run as root. Re-run with sudo."
+    exit 1
+fi
+
+if [[ ! -f "${aapScript}" ]]; then
+    print -u2 "Error: ${aapScript} not found."
+    exit 1
+fi
+
+# ConvertAppsInHomeFolder deletes apps out of ~/Applications during discovery. That is destructive
+# and easy to trigger by accident on a dev machine that installs apps with Homebrew Cask, so a
+# local run refuses to start until it is explicitly turned off or on.
+convertSetting=$(/usr/bin/defaults read /Library/Management/AppAutoPatch/xyz.techitout.appAutoPatch ConvertAppsInHomeFolder 2> /dev/null)
+managedIgnoreSetting=$(/usr/bin/defaults read "/Library/Managed Preferences/xyz.techitout.appAutoPatch" IgnoreAppsInHomeFolder 2> /dev/null)
+if [[ -z "${convertSetting}" ]] && [[ "${managedIgnoreSetting}" != "1" ]] && [[ "${managedIgnoreSetting:u}" != "TRUE" ]]; then
+    print -u2 "Error: neither ConvertAppsInHomeFolder nor IgnoreAppsInHomeFolder is set."
+    print -u2 "A run would delete apps found under ~/Applications (Homebrew Cask installs them there)."
+    print -u2 "Set one first, e.g.:"
+    print -u2 "  sudo defaults write /Library/Management/AppAutoPatch/xyz.techitout.appAutoPatch ConvertAppsInHomeFolder -string FALSE"
+    exit 1
+fi
+
+# Stop the deployed copy so it can't relaunch over this run, and restore it on the way out.
+daemonWasLoaded="FALSE"
+if /bin/launchctl print "system/${launchDaemonLabel}" > /dev/null 2>&1; then
+    daemonWasLoaded="TRUE"
+    print "Unloading ${launchDaemonLabel} for the duration of this run"
+    /bin/launchctl bootout "system/${launchDaemonLabel}" 2> /dev/null
+fi
+
+restore_daemon() {
+    if [[ "${daemonWasLoaded}" == "TRUE" ]] && [[ -f "${launchDaemonPlist}" ]]; then
+        print "Reloading ${launchDaemonLabel}"
+        /bin/launchctl bootstrap system "${launchDaemonPlist}" 2> /dev/null
+    fi
+}
+trap restore_daemon EXIT INT TERM
+
+runArgs=(--verbose-mode --workflow-disable-relaunch "$@")
+
+print "Running ${aapScript} ${runArgs[*]}"
+/bin/zsh "${aapScript}" "${runArgs[@]}"
+exitCode=$?
+
+print "App Auto-Patch exited with code ${exitCode}"
+print "Logs: /Library/Management/AppAutoPatch/logs/aap.log"
+print "      /Library/Management/AppAutoPatch/logs/aap_verbose.log"
+print "      /var/log/Installomator.log"
+
+exit ${exitCode}


### PR DESCRIPTION
## Summary

On a Mac where apps live in `~/Applications` — the default for Homebrew Cask when `HOMEBREW_CASK_OPTS=--appdir=~/Applications`, and common on managed Macs where `/Applications` is restricted — app discovery **deletes** those apps without replacing them.

Three defects chain together:

1. **`ConvertAppsInHomeFolder` defaults to `TRUE`** (line 263). Any discovered label whose app resolves under `/Users/` gets `rm -rf`'d.
2. **The `rm -rf` has no counterpart.** The branch logs `coverting to default directory`, but nothing copies the app to `/Applications`. The app is simply destroyed. On the next pass `mdfind` finds nothing, so Installomator treats the app as absent — and if the subsequent install fails (blocking process, network, Team ID mismatch), nothing replaces it.
3. **`IgnoreAppsInHomeFolder` never took effect.** A configuration profile can deliver it as a real boolean (`<true/>`), which `defaults read` returns as `1`, while discovery compares against the literal string `"TRUE"`. The comparison always failed. Even when set as a string, the `convert` branch is tested *before* the `ignore` branch, so it won regardless.

The Team ID check in `verifyApp()` does not help: it runs *after* the deletion, and a Homebrew-installed app is signed by the same vendor anyway, so it would pass.

Failure is silent from the user's side. Homebrew still lists the cask as installed and the Caskroom entry remains, so `brew list --cask` looks healthy while the app is gone from disk.

## Reproduction

On a Mac with `HOMEBREW_CASK_OPTS=--appdir=~/Applications` and a profile setting `IgnoreAppsInHomeFolder` as a boolean:

```
$ ls -ld ~/Applications/Caffeine.app
drwxr-xr-x@ 3 user staff 96 Sep 21 2025 /Users/user/Applications/Caffeine.app   # v1.1.4

$ sudo appautopatch --verbose-mode --force-discovery

$ ls -ld ~/Applications/Caffeine.app
ls: /Users/user/Applications/Caffeine.app: No such file or directory
$ ls -d /opt/homebrew/Caskroom/caffeine/*/
/opt/homebrew/Caskroom/caffeine/1.1.4/     # brew still believes it is installed
$ ls -ld /Applications/Caffeine.app
ls: /Applications/Caffeine.app: No such file or directory   # nothing was "converted"
```

The verbose log shows `ConvertAppsInHomeFolder: TRUE` / `IgnoreAppsInHomeFolder: 1`, then `coverting to default directory`. The run's own `ConvertedLabels` array records every app it destroyed — on the machine this was found on, 13 of them in a single pass.

## Fix

- Normalize `ConvertAppsInHomeFolder` and `IgnoreAppsInHomeFolder` the way the script already normalizes `VerboseMode` and `DebugMode` (`[[ x -eq 1 ]] || [[ ${x:u} == "TRUE" ]]`), so a boolean from a configuration profile is honored.
- Let `Ignore` win over `Convert` when both are enabled. Not touching an app is recoverable; deleting it is not.
- Test the `ignore` branch before the `convert` branch in discovery.

## Verification

Same Mac, same managed profile, discovery run over all labels with none ignored:

```
line 1411: Both IgnoreAppsInHomeFolder and ConvertAppsInHomeFolder are enabled, honoring Ignore and disabling Convert
ConvertAppsInHomeFolder: FALSE
IgnoreAppsInHomeFolder: TRUE
```

`~/Applications` byte-identical to the pre-run snapshot; all 13 previously-affected apps intact; no `coverting to default directory` anywhere in the log. `zsh -n` clean.

## Not addressed here

`rm -rf $applist` is unquoted and `$applist` is the raw NUL-delimited `mdfind` output, so when a label matches more than one bundle the whole list is passed as a single malformed argument and the `rm` fails. That is why only single-match labels actually destroy an app. Left alone deliberately — it is unreachable once `IgnoreAppsInHomeFolder` is honored, and it deserves its own change. Happy to fold it in if you would rather see it fixed here.

Given the silent nature of the failure, maintainers may also want to consider whether `ConvertAppsInHomeFolder` should default to `TRUE` at all.
